### PR TITLE
Update LX SF ver

### DIFF
--- a/resources/repos.json
+++ b/resources/repos.json
@@ -606,6 +606,7 @@
 				"1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/CS-CoreLib/master/#79\">dev #79</a>"
 			},
 			"Slimefun Version": {
+				"31": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#511\">dev #511</a>",
 				"1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#489\">dev #489</a>"
 			}
 		}


### PR DESCRIPTION
Once https://github.com/TheBusyBiscuit/Slimefun4/pull/1925 is merged then LX 31 is released with this as a required ver.