### PR TITLE
New build of MoreTools needs build 669 of Slimefun to work.

### DIFF
--- a/resources/repos.json
+++ b/resources/repos.json
@@ -768,6 +768,7 @@
 				"1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/CS-CoreLib/master/#90\">dev #90</a>"
 			},
 			"Slimefun Version": {
+				"4": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#669\">dev #669</a>"
 				"1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/stable/#15\">RC-15</a>"
 			}
 		}

--- a/resources/repos.json
+++ b/resources/repos.json
@@ -768,7 +768,7 @@
 				"1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/CS-CoreLib/master/#90\">dev #90</a>"
 			},
 			"Slimefun Version": {
-				"4": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#669\">dev #669</a>"
+				"4": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#669\">dev #669</a>",
 				"1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/stable/#15\">RC-15</a>"
 			}
 		}


### PR DESCRIPTION
## Description
<!-- State what your changes are about -->
Made build #4 and later of MoreTools require #669 of Slimefun4.

## Reason
<!-- Explain WHY you made these changes -->
Because MoreTools' new build needs the changes made in #669 build.
