### PR TITLE
Updated all NCBPFluffyBear addons to be inclusive of future Minecraft versions

### DIFF
--- a/resources/repos.json
+++ b/resources/repos.json
@@ -849,10 +849,10 @@
         },
         "dependencies": {
             "Minecraft Version(s)": {
-                "1": "1.16.x, 1.17.x"
+                "1": "1.16.x+"
             },
             "Slimefun Version": {
-                "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#960\">dev #960</a>"
+                "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#1006\">dev #1006+</a>"
             }
         }
     },
@@ -867,10 +867,10 @@
         },
         "dependencies": {
             "Minecraft Version(s)": {
-                "1": "1.14.x, 1.15.x, 1.16.x"
+                "1": "1.14.x+"
             },
             "Slimefun Version": {
-                "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#960\">dev #960</a>"
+                "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#1006\">dev #1006+</a>"
             }
         }
     },
@@ -885,10 +885,10 @@
         },
         "dependencies": {
             "Minecraft Version(s)": {
-                "1": "1.14.x, 1.15.x, 1.16.x, 1.17.x"
+                "1": "1.14.x+"
             },
             "Slimefun Version": {
-                "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#960\">dev #960</a>"
+                "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#1006\">dev #1006+</a>"
             }
         }
     },
@@ -903,10 +903,10 @@
         },
         "dependencies": {
             "Minecraft Version(s)": {
-                "1": "1.16.x, 1.17.x"
+                "1": "1.16.x+"
             },
             "Slimefun Version": {
-                "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#960\">dev #960</a>"
+                "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/master/#1006\">dev #1006+</a>"
             }
         }
     },


### PR DESCRIPTION
## Description
Updated all Minecraft versions to include 1.18
Updated all Slimefun versions to be #1006 and above

## Reason
Page needed updating for 1.18 release (and future versions)
