### PR TITLE
Add Spirits Unchained to the repos

### DIFF
--- a/resources/repos.json
+++ b/resources/repos.json
@@ -1684,5 +1684,23 @@
                 "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/stable/#32\">RC-31 or higher</a>"
             }
         }
+    },
+    "JustAHuman-xD/SpiritsUnchained:master": {
+        "sonar": {
+            "enabled": false
+        },
+        "options": {
+            "prefix": "DEV",
+            "abandoned": false,
+            "createJar": true
+        },
+        "dependencies": {
+            "Minecraft Version(s)": {
+                "1": "1.19x"
+            },
+            "Slimefun Version": {
+                "1": "<a class=\"link_info\" href=\"/builds/TheBusyBiscuit/Slimefun4/stable/#32\">RC-31 or higher</a>"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
The only changes just add an entry to the repos file to include my new addon SpiritsUnchained

## Reason
I am releasing SpiritsUnchained either very soon or after I make this PR and it would be great if it could be addon to the auto builder and to the sf addon wiki page (which I plan to make a PR for after this). It's essentially a standard for any mainstream addons to have their addon on here and the wiki page.