### PR TITLE
Fix the config for ExtraHeads

### DIFF
--- a/resources/repos.json
+++ b/resources/repos.json
@@ -438,7 +438,7 @@
             "host-url": "https://sonarcloud.io"
         },
         "options": {
-            "custom_directory": "TheBusyBiscuit/MobCapturer/master",
+            "custom_directory": "TheBusyBiscuit/ExtraHeads/master",
             "prefix": "DEV",
             "abandoned": false,
             "createJar": true


### PR DESCRIPTION
## Description
<!-- State what your changes are about -->
Change the custom dir of ExtraHeads to correct one.

## Reason
<!-- Explain WHY you made these changes -->
The builds page for MobCapturer and ExtraHeads are both broken.